### PR TITLE
CHORE: Implement common pool

### DIFF
--- a/src/pages/MarketPage.vue
+++ b/src/pages/MarketPage.vue
@@ -945,6 +945,7 @@ export default defineComponent({
 
     this._restoreFromStorage();
 
+    this.pool = new NostrTools.SimplePool();
     const params = new URLSearchParams(window.location.search);
 
     await this.addMarket(params.get("naddr"));
@@ -1456,8 +1457,7 @@ export default defineComponent({
           selected: true,
         };
 
-        const pool = new NostrTools.SimplePool();
-        const event = await pool.get(market.relays, {
+        const event = await this.pool.get(market.relays, {
           kinds: [30019],
           limit: 1,
           authors: [market.pubkey],


### PR DESCRIPTION
noticed you have a `pool` data variable that looks like it wants to be used

at the moment, a pool is created every time you run addMarket(). 

Now, set the data variable `pool` to a `new NostrTools.SimplePool();` in the `created()` hook. 

Then use this across functions, e.g., in the `addMarket()` function