### PR TITLE
FIX: filter out non-active products

### DIFF
--- a/src/pages/MarketPage.vue
+++ b/src/pages/MarketPage.vue
@@ -798,6 +798,8 @@ export default defineComponent({
         !this.filterData.priceTo || price <= this.filterData.priceTo;
       const isInActiceStall = (stallId) =>
         !this.activeStall || stallId == this.activeStall;
+      const isActive = (active) =>
+        active;
 
       let products = this.products.filter(
         (p) =>
@@ -808,7 +810,8 @@ export default defineComponent({
           isInStall(p.stall_id) &&
           hasCurrency(p.currency) &&
           hasPriceFrom(p.price) &&
-          hasPriceTo(p.price)
+          hasPriceTo(p.price) &&
+          isActive(p.active)
       );
 
       products.sort((a, b) =>


### PR DESCRIPTION
Following this [commit](https://github.com/lnbits/nostrmarket/commit/2020bd9838047bf8d05bd2f01f9f37aba0d7729c) for nostrmarket which makes sure to update the `active` boolean for a `product` , I noticed there wasn't any way that the front end filters out items that are not active.

The PR is assuming that non-active products should be in the `products` list at all, otherwise something like the following could be done so that it is either not added to `products` or removed if the status changed

```diff
diff --git a/src/pages/MarketPage.vue b/src/pages/MarketPage.vue
index b257065..00aa1ab 100644
--- a/src/pages/MarketPage.vue
+++ b/src/pages/MarketPage.vue
@@ -1339,4 +1339,5 @@ export default defineComponent({
       this._processProduct({
         ...p,
+        active: p.active,
         stallName: stall.name,
         images: p.images || [p.image],
@@ -1354,5 +1355,6 @@ export default defineComponent({
         (p) => p.id === product.id && p.pubkey === product.pubkey
       );
-      if (productIndex === -1) {
+      if (productIndex === -1 && product.active) {
+        // Add new product
         this.products.push(product);
         return;
@@ -1362,5 +1364,9 @@ export default defineComponent({
         ...new Set(product.relayUrls.concat(existingProduct.relayUrls)),
       ];
-      if (existingProduct.createdAt < product.createdAt) {
+      if (existingProduct && !product.active) {
+        // remove product if not active
+        this.products.splice(productIndex, 1);
+      } else if (existingProduct.createdAt < product.createdAt) {
+        // Update existing product if newer
         this.products.splice(productIndex, 1, product);
       }

```
