### PR TITLE
IMPROVEMENT: update markets by fetching 30019 events

### DIFF
--- a/src/pages/MarketPage.vue
+++ b/src/pages/MarketPage.vue
@@ -442,7 +442,7 @@
                 <li>
                   <span class="text-h6">
                     <q-btn
-                      @click="addMarket(defaultMarketNaddr)"
+                      @click="addUpdateMarket(defaultMarketNaddr)"
                       size="xl"
                       flat
                       color="secondary"
@@ -763,7 +763,7 @@ export default defineComponent({
             .dialog(confirm("Do you want to import this market profile?"))
             .onOk(async () => {
               this.searchText = "";
-              await this.addMarket(n);
+              await this.addUpdateMarket(n);
             });
         } catch {}
       }
@@ -947,7 +947,8 @@ export default defineComponent({
 
     const params = new URLSearchParams(window.location.search);
 
-    await this.addMarket(params.get("naddr"));
+    this.markets.forEach(market => this.addUpdateMarket(market.naddr, false));
+    await this.addUpdateMarket(params.get("naddr"));
     await this._handleQueryParams(params);
 
     this.isLoading = false;
@@ -1441,7 +1442,7 @@ export default defineComponent({
         this.setActivePage("market-config");
       }
     },
-    async addMarket(naddr) {
+    async addUpdateMarket(naddr, modUI = true) {
       if (!naddr) return;
 
       try {
@@ -1451,6 +1452,7 @@ export default defineComponent({
 
         const market = {
           d: data.identifier,
+          naddr: naddr,
           pubkey: data.pubkey,
           relays: data.relays,
           selected: true,
@@ -1468,6 +1470,9 @@ export default defineComponent({
 
         if (isJson(event.content)) {
           market.opts = JSON.parse(event.content);
+        }
+
+        if (modUI) {
           this.$q
             .dialog(
               confirm(


### PR DESCRIPTION
Currently, the client never synchronizes with the latest `naddr` state. This is because the `30019` is only fetched when the market is added.

With this code, I make a small change to the `addMarket()` function, adding a boolean parameter to disable the dialog boxes for the "update" aspect of it and rename it `addUpdateMarket(naddr, modUi=true)` 

On the `created()` lifecycle hook, the client loops through the markets stored in localStorage and run `addUpdateMarket(market, false)`. The loaded UI will remain whatever is in localStorage.

in the addUpdateMarket() function, the new `30019` event is retrieved, updating the merchants, stalls, etc for the marketplace. 

Additionally, the `market` object is updated to include its naddr